### PR TITLE
Add Python 3.11 to the build matrix

### DIFF
--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- vs2019
+channel_sources:
+- conda-forge
+channel_targets:
+- ocefpaf test
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+numpy:
+- '1.23'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- win-64
+vc:
+- '14'
+zip_keys:
+- - python
+  - numpy
+zlib:
+- '1.2'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -22,6 +22,9 @@ jobs:
           - CONFIG: win_64_numpy1.21python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: windows
+          - CONFIG: win_64_numpy1.23python3.11.____cpython
+            UPLOAD_PACKAGES: True
+            os: windows
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
Probably won't make a post release. We can get the artifact from the PR.